### PR TITLE
debug: line51, 'y_mask' change to 'y_center'

### DIFF
--- a/camelyon16/data/wsi_producer.py
+++ b/camelyon16/data/wsi_producer.py
@@ -48,7 +48,7 @@ class WSIPatchDataset(Dataset):
         y_center = int((y_mask + 0.5) * self._resolution)
 
         x = int(x_center - self._image_size / 2)
-        y = int(y_mask - self._image_size / 2)
+        y = int(y_center - self._image_size / 2)
 
         img = self._slide.read_region(
             (x, y), 0, (self._image_size, self._image_size)).convert('RGB')


### PR DESCRIPTION
Debug for a long time, and finally found that it is a wrong problem. The wrong reason will cause each img to be a small patch in the upper left corner. The final predicted heat map is all the tissue mask.